### PR TITLE
Prevent path problems on Windows Azure network shares

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var path       = require('path')
   ;
 
 function splitPath(path) {
-  var parts = path.split(/(\/|\\)/); 
+  var parts = path.split(/(\/|\\)/);
   if (!parts.length) return parts;
 
   // when path starts with a slash, the first part is empty string
@@ -35,7 +35,7 @@ exports.sync = function (currentFullPath, clue) {
   function testDir(parts) {
     if (parts.length === 0) return null;
 
-    var p = path.join.apply(path, parts);
+    var p = parts.join('');
 
     var itdoes = existsSync(path.join(p, clue));
     return itdoes ? p : testDir(parts.slice(0, -1));


### PR DESCRIPTION
Hi there,

we're using "browserify-shim" in a Windows Azure NodeJS environment and it fails to load the project package.json file:

```
Trace: { [Error: Cannot find module 'package.json'] code: 'MODULE_NOT_FOUND' }
    at \\100.90.92.64\volume-12-default\a05dc12ece3444c92608\b31d4519a7be4dfd87ae0966a87ec5b3\site\wwwroot\node_modules\browserify-shim\lib\resolve-shims.js:216:17
    at \\100.90.92.64\volume-12-default\a05dc12ece3444c92608\b31d4519a7be4dfd87ae0966a87ec5b3\site\wwwroot\node_modules\browserify-shim\node_modules\find-parent-dir\index.js:16:26
    at Object.cb [as oncomplete] (fs.js:168:19)
Error: Cannot find module 'package.json'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at \\100.90.92.64\volume-12-default\a05dc12ece3444c92608\b31d4519a7be4dfd87ae0966a87ec5b3\site\wwwroot\node_modules\browserify-shim\lib\resolve-shims.js:183:16
    at \\100.90.92.64\volume-12-default\a05dc12ece3444c92608\b31d4519a7be4dfd87ae0966a87ec5b3\site\wwwroot\node_modules\browserify-shim\node_modules\find-parent-dir\index.js:16:26
    at Object.cb [as oncomplete] (fs.js:168:19)
```

Further investigation showed that recomposing the path elements on traversing paths in the "find-parent-dir" module is the problem, because "path.join" seems to fail when the path starts with double slash (Windows network shares do start with double slashes).

A simple Array.join can fix the problem, since the "parts" array already holds all required path elements and a simple concatenation will restore the original path.
