### PR TITLE
fix(pkg): fix main file

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "find-parent-dir",
   "version": "0.3.0",
   "description": "Finds the first parent directory that contains a given file or directory.",
-  "main": "find-parent-dir.js",
+  "main": "index.js",
   "scripts": {
     "test": "tap test/*.js"
   },


### PR DESCRIPTION
There is no `find-parent-dir.js` file in this package, only a `index.js`. 
This fix this error when using Yarn Plug'n'play:

```
Error: Couldn't find a suitable Node resolution for unqualified path "/home/kocal/.cache/yarn/v3/npm-find-parent-dir-0.3.0-33c44b429ab2b2f0646299c5f9f718f376ff8d54/node_modules/find-parent-dir"
```
