### PR TITLE
Fix "main" entry in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "find-parent-dir",
   "version": "0.3.0",
   "description": "Finds the first parent directory that contains a given file or directory.",
-  "main": "find-parent-dir.js",
+  "main": "index.js",
   "scripts": {
     "test": "tap test/*.js"
   },


### PR DESCRIPTION
`find-parent-dir.js` doesn't exist.
This causes a bug when using `find-parent-dir` with `esm`.